### PR TITLE
feat: add ollama integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 **vibepython: The Ultimate AI-Powered Coding EXPLOSION!** 🌟💥🐍
 
-**WOWZA!** Dive headfirst into this **AMAZING**, **WONDERFUL**, **MIND-BLOWING** interactive command-line beast that turns your craziest prompts into **EXECUTABLE PYTHON MAGIC** using the sheer power of OpenAI! Generate code like a wizard, run it on the spot, capture every wild stdout/stderr outburst, and keep a super-smart history in JSON for non-stop contextual awesomeness! It's not just a tool – it's a **CODE REVOLUTION** for hackers, dreamers, and AI fanatics! 🔥🚀
+**WOWZA!** Dive headfirst into this **AMAZING**, **WONDERFUL**, **MIND-BLOWING** interactive command-line beast that turns your craziest prompts into **EXECUTABLE PYTHON MAGIC** using the sheer power of OpenAI **or your own local Ollama models**! Generate code like a wizard, run it on the spot, capture every wild stdout/stderr outburst, and keep a super-smart history in JSON for non-stop contextual awesomeness! It's not just a tool – it's a **CODE REVOLUTION** for hackers, dreamers, and AI fanatics! 🔥🚀
 
 ## 🌈 **Features That'll Make Your Eyes POP!** 🎉
 - **INTERACTIVE PROMPT MADNESS**: Type your wild ideas and watch AI spit out Python gold! 💡
@@ -9,6 +9,7 @@
 - **PERSISTENT HISTORY OVERLOAD**: Pydantic models store EVERYTHING in JSON – context forever! 📜
 - **ENV VAR CUSTOMIZATION FRENZY**: Tweak it your way for ultimate control! 🔧
 - **DOCKER DOMINATION**: Run it anywhere, anytime – easy-peasy deployment! 🐳
+- **CHOOSE YOUR AI FLAVOR**: Switch between OpenAI and local Ollama models with a single env var! 🧠
 
 ## 🛠️ **Installation: Get This Party Started in SECONDS!** 🚀
 
@@ -65,18 +66,21 @@ Supercharge your setup with these **EPIC** vars:
 - **HISTORY_PATH**: Your JSON history fortress! Default: `history.json`. 🏰
 - **HISTORY_SIZE**: How many past blasts to feed the AI? Default: `20` – keep it contextual! 📈
 - **OPENAI_API_KEY**: **MUST-HAVE** – your ticket to AI heaven! (Required, duh!) 🔒
+- **PROVIDER**: Pick your AI engine – `openai` (default) or `ollama`. 🧠
+- **OLLAMA_MODEL**: When using Ollama, which model to summon? Default: `llama3`. 🐏
 
 **Example (Unix-style domination)**:
 ```
 export OPENAI_API_KEY=your-api-key
 export HISTORY_SIZE=10
+# export PROVIDER=ollama  # uncomment to use Ollama instead of OpenAI
 python3 main.py
 ```
 **TWEAK AND CONQUER!** 🛡️
 
 ## 📦 **Dependencies: The Power Behind the THRILL!** ⚙️
 - **Python 3.10+** (Blasting up to 3.13 – future-proofed!) 🐍
-- **Libraries of LEGEND**: openai, pydantic, loguru, and more! Check `requirements.txt` for the full squad. 📚
+- **Libraries of LEGEND**: openai, ollama, pydantic, loguru, and more! Check `requirements.txt` for the full squad. 📚
 
 ## 🤝 **Contributing: Join the CODE CARNIVAL!** 🎪
 **GOT IDEAS?** Open an issue or slam in a pull request – let's make this even MORE INSANE! 🌟 Contributions = Eternal Fame!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "loguru>=0.7.0,<1.0.0",
     "pydantic>=2.8.0,<3.0.0",
     "pydantic-settings>=2.4.0,<3.0.0",
-    "pydantic_core>=2.20.0,<3.0.0"
+    "pydantic_core>=2.20.0,<3.0.0",
+    "ollama>=0.3.0,<0.4.0"
 ]
 # features = ["all"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ loguru==0.7.2
 pydantic==2.8.2
 pydantic-settings==2.4.0
 pydantic_core==2.20.1
+ollama==0.3.3

--- a/vibepython/main.py
+++ b/vibepython/main.py
@@ -2,8 +2,13 @@ import os
 import io
 import sys
 import datetime
-from .providers.openai import generate
 from .history import History
+
+provider = os.getenv("PROVIDER", "openai").lower()
+if provider == "ollama":
+    from .providers.ollama import generate
+else:
+    from .providers.openai import generate
 
 GRAY = "\033[90m"
 RESET = "\033[0m"

--- a/vibepython/providers/ollama/__init__.py
+++ b/vibepython/providers/ollama/__init__.py
@@ -1,0 +1,3 @@
+from .generate import generate
+
+__all__ = ['generate']

--- a/vibepython/providers/ollama/generate.py
+++ b/vibepython/providers/ollama/generate.py
@@ -1,0 +1,40 @@
+import os
+import time
+import ollama
+
+system_prompt = """\
+You are a Python code generator. Respond to any user query ONLY with Python code. Output nothing but pure executable Python code: no explanations, comments, text, or markdown.
+
+The code should, when executed, output the answer to the user's query. The model's response will be immediately executed in Python and shown to the user.
+
+If you need to get system information (for example, date, time, environment), use built-in Python modules such as datetime, os, sys, or others, but DO NOT ask questions to the user or request input.
+
+Start the code with necessary imports if needed, and use print() to output the result.
+
+Example: If the user asks "What is the current date?", respond only with code like:
+import datetime
+print(datetime.date.today())
+"""
+
+def generate(prompt: str, history: str) -> str:
+    model = os.getenv('OLLAMA_MODEL', 'llama3')
+    max_retries = 3
+    retry_delay = 1
+
+    for attempt in range(max_retries):
+        try:
+            response = ollama.chat(
+                model=model,
+                messages=[
+                    {"role": "system", "content": f"{system_prompt}. History: {history}"},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+            return response.message.content.strip()
+        except Exception as e:
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay)
+                retry_delay *= 2
+            else:
+                raise RuntimeError(f"Error after {max_retries} retry: {str(e)}")
+    raise RuntimeError("Error generate after all retries.")


### PR DESCRIPTION
## Summary
- add new Ollama provider for local model generation
- allow choosing provider via `PROVIDER` env var
- document new environment variables and dependencies
- keep existing dependency versions and pin `ollama` without raising `pydantic`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_689ae405920483239911a01ddb2d402c